### PR TITLE
using openjdk:8-jdk as base image instead of java:openjdk-8-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jdk
+FROM openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y base-files lsb-release lsb-base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM openjdk:8-jdk
 
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now Archived
 
-RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list && \
-  sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-
-RUN  apt-get -o Acquire::Check-Valid-Until=false update && \
-  apt-get install -y base-files lsb-release lsb-base
+RUN apt-get update && apt-get install -y base-files lsb-release lsb-base
 
 # default 1.15.0, override with --build-arg switch
 ARG VERSION="1.15.0"


### PR DESCRIPTION
using openjdk:8-jdk ([https://hub.docker.com/_/openjdk](https://hub.docker.com/_/openjdk)) as base image instead of java:openjdk-8-jdk ([https://hub.docker.com/_/java](https://hub.docker.com/_/java)) to avoid debian jessie apt update issue