### PR TITLE
Fix out of memory issue by allowing custom memory settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ docker build -t apache-drill:1.17.0 . --build-arg VERSION="1.17.0"
 docker run -dit --rm --name drill -v /data:/data:ro -p 8047:8047 -p 31010:31010 apache-drill:1.17.0
 ```
 
+## Apache Drill memory
+#### Memory can be configured by passing environment variables as following:
+##### NOTE that without passing the env variables, memory settings configured to work with DSRI at UM will be applied.
+```
+docker run -dit --rm -p 8047:8047 -p 31010:31010 --name drill \
+	-e DRILLBIT_MAX_PROC_MEM='8G' \
+	-e DRILL_HEAP='4G' \
+	-e DRILL_MAX_DIRECT_MEMORY='3G' \
+	-e DRILLBIT_CODE_CACHE_SIZE='1G' \
+	-v /data:/data:ro apache-drill
+```
+
+
 ## Test
 1. Navigate to http://localhost:8047
 2. Try following query ```show files in dfs.root.`/data/` ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-bash /opt/drill/apache-drill-${DRILL_VERSION}/bin/auto-setup.sh
+export DRILLBIT_MAX_PROC_MEM=${DRILLBIT_MAX_PROC_MEM:-"420G"}
+export DRILL_HEAP=${DRILL_HEAP:-"218G"}
+export DRILL_MAX_DIRECT_MEMORY=${DRILL_MAX_DIRECT_MEMORY:-"200G"}
+export DRILLBIT_CODE_CACHE_SIZE=${DRILLBIT_CODE_CACHE_SIZE:-"2G"}
+
 bash /opt/drill/apache-drill-${DRILL_VERSION}/bin/drill-embedded


### PR DESCRIPTION
In this pull request, I removed the auto config carried by the auto-setup.sh script and I replaced that by setting 4 environment variables responsible for setting the memory for Apache Drill:

DRILLBIT_MAX_PROC_MEM is the maximum memory allowed which should not be more than the memory available for the docker container

DRILL_HEAP is the JVM heap space memory

DRILL_MAX_DIRECT_MEMORY is the memory that can be utilized from outside JVM for I/O operation to make it more faster (should be balanced with DRILL_HEAP when handling big files)

DRILLBIT_CODE_CACHE_SIZE is a cache memory which can not be more than 2G, otherwise Apache Drill will not start so keep it under that number